### PR TITLE
Reformat Markdown, removing double newlines

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -121,7 +121,7 @@ export default class LimitlessLifelogsPlugin extends Plugin {
 	private formatLifelogMarkdown(lifelog: any): string {
 		if (lifelog.markdown) {
 			// Reformat Markdown
-			const reformattedMarkdown = lifelog.markdown.replaceAll("\n\n", "\n");
+			const reformattedMarkdown = lifelog.markdown.replaceAll('\n\n', '\n');
 			return reformattedMarkdown;
 		}
 

--- a/main.ts
+++ b/main.ts
@@ -120,7 +120,9 @@ export default class LimitlessLifelogsPlugin extends Plugin {
 
 	private formatLifelogMarkdown(lifelog: any): string {
 		if (lifelog.markdown) {
-			return lifelog.markdown;
+			// Reformat Markdown
+			const reformattedMarkdown = lifelog.markdown.replaceAll("\n\n", "\n");
+			return reformattedMarkdown;
 		}
 
 		const content: string[] = [];


### PR DESCRIPTION
Allows Obisidian note to be more condensed and easier to read and search through.